### PR TITLE
fix(services): prevent adding a null service when deleted from db

### DIFF
--- a/internal/db/service.go
+++ b/internal/db/service.go
@@ -85,8 +85,9 @@ func GetTrendingServices(bookings []Booking) ([]Service, error) {
 		}); err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
 		} else if err != nil {
 			return nil, err
+		} else {
+			services = append(services, *service)
 		}
-		services = append(services, *service)
 	}
 
 	return services, nil


### PR DESCRIPTION
The previous version of this code added service to the list of trending services even when it no longer exists in the database. This pull request fixes that.