### PR TITLE
fix(db): prevent nil slice in json response due to uninitialized slice

### DIFF
--- a/internal/db/product.go
+++ b/internal/db/product.go
@@ -68,7 +68,7 @@ func AllProducts() ([]Product, error) {
 
 // TrendingProducts returns the top ten trending products.
 func TrendingProducts(items []Item) ([]Product, error) {
-	var products []Product
+	products := make([]Product, 0)
 
 	for _, item := range items {
 		product := new(Product)

--- a/internal/db/service.go
+++ b/internal/db/service.go
@@ -77,7 +77,8 @@ func DeleteService(id string) error {
 
 // GetTrendingServices retrieves the top 10 services in the last week if available.
 func GetTrendingServices(bookings []Booking) ([]Service, error) {
-	var services []Service
+	services := make([]Service, 0)
+
 	for _, booking := range bookings {
 		service := new(Service)
 		if err := Connector.Query(func(tx *gorm.DB) error {


### PR DESCRIPTION
The previous version of this code returned null as the json value for a slice that was declared but never initialized, either directly or by `GORM`. In the updated version, if a slice can possibly be returned without being initialized, it is initialized using `make`.