### PR TITLE
fix(db): validate product availability during order

### DIFF
--- a/internal/db/item.go
+++ b/internal/db/item.go
@@ -130,6 +130,10 @@ func validateStock(items []Item) error {
 			return err
 		}
 
+		if *product.Stock == 0 {
+			return errors.New("Product is out of stock")
+		}
+
 		if *item.Quantity > *product.Stock {
 			*item.Quantity = *product.Stock
 		}


### PR DESCRIPTION
The previous version of this code failed to determine whether the product is in stock before confirming it as part of the order. Stock validation is done at other stages like when adding to cart and when updating item quantity, but never when ordering. This will fix a scenario where by an item with 0 quantity and 0 amount is added to the order.