### PR TITLE
fix: properly validate shipping address when creating a new order

### DIFF
--- a/internal/api/v1/handlers/orders.go
+++ b/internal/api/v1/handlers/orders.go
@@ -202,8 +202,10 @@ func newOrder(newOrder *NewOrder, items []db.Item) *db.Order {
 	order.Items = items
 	order.TotalAmount = getOrderTotal(items)
 
-	if *newOrder.DeliveryMethod == "delivery" && newOrder.ShippingAddress != nil {
-		order.ShippingAddress = newOrder.ShippingAddress
+	if *newOrder.DeliveryMethod == "delivery" {
+		if newOrder.ShippingAddress != nil && *newOrder.ShippingAddress != "" {
+			order.ShippingAddress = newOrder.ShippingAddress
+		}
 	}
 
 	return order


### PR DESCRIPTION
This commit takes care of the scenario whereby the shipping address is provided but as an empty string.

Previously, we assumed the key would not be provided at all, and used the key not being present to
indicate no shipping address was provided. This PR now checks for an empty string as well.