### PR TITLE
fix(db): find orders and bookings only when `id` starts with substring

### DIFF
--- a/backend/internal/api/v1/handlers/bookings.go
+++ b/backend/internal/api/v1/handlers/bookings.go
@@ -77,7 +77,7 @@ func CustomerGetBooking(ctx *gin.Context) {
 	}
 
 	for _, booking := range user.Bookings {
-		if strings.Contains(*booking.ID, booking_id) {
+		if strings.HasPrefix(*booking.ID, booking_id) {
 			ctx.JSON(http.StatusOK, gin.H{
 				"data": booking,
 			})

--- a/backend/internal/db/booking.go
+++ b/backend/internal/db/booking.go
@@ -31,7 +31,7 @@ func (booking *Booking) LoadFromDB(id string) error {
 	}
 
 	if err := Connector.Query(func(tx *gorm.DB) error {
-		return tx.Preload("Slot").Preload("Service").First(booking, "id LIKE ?", "%"+id+"%").Error
+		return tx.Preload("Slot").Preload("Service").First(booking, "id LIKE ?", id+"%").Error
 	}); err != nil {
 		return err
 	}

--- a/backend/internal/db/order.go
+++ b/backend/internal/db/order.go
@@ -30,7 +30,7 @@ func (order *Order) LoadFromDB(id string) error {
 
 	if err := Connector.Query(func(tx *gorm.DB) error {
 		return tx.Preload("Items.Product").
-			First(order, "id LIKE ?", "%"+id+"%").Error
+			First(order, "id LIKE ?", id+"%").Error
 	}); err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func (order *Order) CustomerLoadFromDB(userID, id string) error {
 	if err := Connector.Query(func(tx *gorm.DB) error {
 		return tx.Where("user_id = ?", userID).
 			Preload("Items.Product").
-			First(order, "id LIKE ?", "%"+id+"%").Error
+			First(order, "id LIKE ?", id+"%").Error
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
The previous version of this code matched the order or booking with the given substring regardless of the position of the substring in the id. This increases the chances of matching unintended orders and bookings. To reduce this risk, we only match the id if the substring starts the id as we would be expecting from the order or booking reference.