### PR TITLE
fix: correct boundary condition in status validation functions

### DIFF
--- a/backend/internal/api/v1/handlers/bookings.go
+++ b/backend/internal/api/v1/handlers/bookings.go
@@ -261,7 +261,7 @@ func isValidBookingStatus(booking *db.Booking, status string) bool {
 	var isValidStatus bool
 
 	for i, stat := range validBookingStatuses {
-		if i == len(validBookingStatuses) && stat != status {
+		if i == len(validBookingStatuses)-1 && stat != status {
 			isValidStatus = false
 			break
 		}

--- a/backend/internal/api/v1/handlers/orders.go
+++ b/backend/internal/api/v1/handlers/orders.go
@@ -371,7 +371,7 @@ func isValidOrderStatus(order *db.Order, status string) bool {
 	var isValidStatus bool
 
 	for i, stat := range validOrderStatuses {
-		if i == len(validOrderStatuses) && stat != status {
+		if i == len(validOrderStatuses)-1 && stat != status {
 			isValidStatus = false
 			break
 		}


### PR DESCRIPTION
In the previous version of this code, the functions `isValidOrderStatus` and `isValidBookingStatus` looped over the slice of valid statuses and were expected to perform an operation when at the end of each slice. However, the condition that checks if the loop is at the last iteration was erroneous, as it checked if the index `i` was equal to the length of the slice as opposed to the length minus 1.