### PR TITLE
backend: add new route to search products by name

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1501,6 +1501,49 @@ const docTemplate = `{
                 }
             }
         },
+        "/products/search/{name}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Retrieves a list of all products in given substring ` + "`" + `name` + "`" + ` in their name.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name to search for",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "data",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/products/{product_id}": {
             "get": {
                 "produces": [

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1489,6 +1489,49 @@
                 }
             }
         },
+        "/products/search/{name}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "products"
+                ],
+                "summary": "Retrieves a list of all products in given substring `name` in their name.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name to search for",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "data",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/products/{product_id}": {
             "get": {
                 "produces": [

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1263,6 +1263,36 @@ paths:
       summary: Retrieves a list of all products in given category
       tags:
       - products
+  /products/search/{name}:
+    get:
+      parameters:
+      - description: The name to search for
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: data
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: error
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: error
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Retrieves a list of all products in given substring `name` in their
+        name.
+      tags:
+      - products
   /reset_password:
     post:
       consumes:

--- a/backend/internal/api/v1/README.md
+++ b/backend/internal/api/v1/README.md
@@ -37,6 +37,12 @@ where applicable, as well as response codes and types.
     the given category.
     On failure, it will return a <b>400</b> or <b>500</b> response code and an <b>error</b> string in the payload.
     </li>
+    <li><h4>/products/search/{name}</h4>
+    Get all products in a given substring `name` in their name. The search is case insensitive.
+    On success, it will return a <b>200</b> response code with a <b>data</b> object in the payload. This will be a list of all product objects with
+    the given substring `name`.
+    On failure, it will return a <b>400</b> or <b>500</b> response code and an <b>error</b> string in the payload.
+    </li>
     <li><h4>/cart *</h4>
     Get all items in the user's cart.
     On success, it will return a <b>200</b> response code with a <b>data</b> object in the payload. This will be a list of all item objects in

--- a/backend/internal/api/v1/handlers/products.go
+++ b/backend/internal/api/v1/handlers/products.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -79,6 +80,35 @@ func GetProductByID(ctx *gin.Context) {
 
 	ctx.JSON(http.StatusOK, gin.H{
 		"data": product,
+	})
+}
+
+// GetProductsByName	Get products with the given substring in name.
+//
+//	@Summary	Retrieves a list of all products in given substring `name` in their name.
+//	@Tags		products
+//	@Produce	json
+//	@Param		name	path		string					true	"The name to search for"
+//	@Success	200		{object}	map[string]interface{}	"data"
+//	@Failure	400		{object}	map[string]interface{}	"error"
+//	@Failure	500		{object}	map[string]interface{}	"error"
+//	@Router		/products/search/{name} [get]
+func GetProductsByName(ctx *gin.Context) {
+	name := ctx.Param("name")
+	if name == "" {
+		AbortCtx(ctx, http.StatusBadRequest, errors.New("Product name not set in cxt"))
+		return
+	}
+
+	name = strings.ToLower(name)
+	products, err := db.GetProductsByName(name)
+	if err != nil {
+		AbortCtx(ctx, http.StatusInternalServerError, errors.New("Failed to get products by name"))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"data": products,
 	})
 }
 

--- a/backend/internal/api/v1/handlers/products.go
+++ b/backend/internal/api/v1/handlers/products.go
@@ -146,7 +146,7 @@ func GetProductsByCategory(ctx *gin.Context) {
 		return
 	}
 
-	products, err := db.ProductCategory(category)
+	products, err := db.GetProductsByCategory(category)
 	if err != nil {
 		AbortCtx(ctx, http.StatusInternalServerError, err)
 		return

--- a/backend/internal/api/v1/routes/products.go
+++ b/backend/internal/api/v1/routes/products.go
@@ -10,6 +10,7 @@ func ProductsRoutes(api *gin.RouterGroup) {
 	api.GET("/products", handlers.GetProducts)
 	api.GET("/products/:product_id", handlers.GetProductByID)
 	api.GET("/products/categories/:category", handlers.GetProductsByCategory)
+	api.GET("/products/search/:name", handlers.GetProductsByName)
 }
 
 // AdminProductsRoutes adds all routes for the admin products endpoint.

--- a/backend/internal/db/product.go
+++ b/backend/internal/db/product.go
@@ -107,3 +107,21 @@ func DeleteProduct(id string) error {
 
 	return nil
 }
+
+// GetProductsByName gets all products in the database containing the substring
+// `name` using a case insensitive search.
+func GetProductsByName(name string) ([]Product, error) {
+	var products []Product
+
+	if err := Connector.Query(func(tx *gorm.DB) error {
+		// This insensitive search is dependent on the character set the database
+		// is configured in, in this case `utf8mb4`.
+		return tx.
+			Where("name COLLATE utf8mb4_general_ci LIKE ?", "%"+name+"%").
+			Order("name").
+			Find(&products).Error
+	}); err != nil {
+		return nil, err
+	}
+	return products, nil
+}

--- a/backend/internal/db/product.go
+++ b/backend/internal/db/product.go
@@ -84,8 +84,8 @@ func TrendingProducts(items []Item) ([]Product, error) {
 	return products, nil
 }
 
-// ProductCategory gets all the products belonging to the given category.
-func ProductCategory(category string) ([]Product, error) {
+// GetProductsByCategory gets all the products belonging to the given category.
+func GetProductsByCategory(category string) ([]Product, error) {
 	var products []Product
 
 	if err := Connector.Query(func(tx *gorm.DB) error {


### PR DESCRIPTION
This PR includes a new route for searching for products by their name, `api/v1/products/search/{:name}`. The search is case-insensitive and can be performed with as little as a substring the name.